### PR TITLE
fix: fix config not load

### DIFF
--- a/CommandPlugin.cpp
+++ b/CommandPlugin.cpp
@@ -3,8 +3,9 @@
 #include "ui/CommandPluginSettings.hpp"
 #include "ui/GUIInterface.hpp"
 
-bool CommandPlugin::InitializePlugin(const QString &, const QJsonObject &)
+bool CommandPlugin::InitializePlugin(const QString &, const QJsonObject &conf)
 {
+    Qv2rayInterface::UpdateSettings(conf);
     CommandPluginInstance = this;
     eventHandler = std::make_shared<SimpleEventHandler>();
     guiInterface = new CommandGUIInterface();


### PR DESCRIPTION
临时解决修复配置不加载的问题，建议修改 QvPlugin-Interface 部分的代码以永久解决问题
具体为修改 [InitializePlugin 虚函数](https://github.com/Qv2ray/QvPlugin-Interface/blob/911c4adbb7b598435162da245ab248d215d3f018/QvPluginInterface.hpp#L26)，使其有 [UpdateSettings 函数](https://github.com/Qv2ray/QvPlugin-Interface/blob/911c4adbb7b598435162da245ab248d215d3f018/QvPluginInterface.hpp#L52-L55) 相同的功能